### PR TITLE
added a way to get the geohash's precision

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<groupId>ch.hsr</groupId>
 	<artifactId>geohash</artifactId>
 	<packaging>jar</packaging>
-	<version>1.0.8</version>
+	<version>1.0.9-SNAPSHOT</version>
 	<name>geohash-java</name>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -31,4 +31,14 @@
 			</plugin>
 		</plugins>
 	</build>
+	<distributionManagement>
+	  <repository>
+		<id>releases</id>
+		<url>http://sunnexus0b00.dev.weather.com/nexus/content/repositories/releases/</url>
+	  </repository>
+	  <snapshotRepository>
+		<id>snapshots</id>
+		<url>http://sunnexus0b00.dev.weather.com/nexus/content/repositories/snapshots/</url>
+	  </snapshotRepository>
+	</distributionManagement>
 </project>

--- a/src/main/java/ch/hsr/geohash/GeoHash.java
+++ b/src/main/java/ch/hsr/geohash/GeoHash.java
@@ -168,6 +168,13 @@ public final class GeoHash implements Comparable<GeoHash>, Serializable {
 				longitudeRange[1]));
 	}
 
+	public int getCharacterPrecision() {
+	 	if (significantBits % 5 != 0) {
+		    throw new IllegalStateException("precision of GeoHash is not divisble by 5: "+this);
+		} 
+		return significantBits / 5;
+	}
+
 	public GeoHash next(int step) {
 		return fromOrd(ord() + step, significantBits);
 	}


### PR DESCRIPTION
Please ignore the changes to the POM, those were made to integrate the change into our internal build process.

Added a helper method that gives the character precision of the GeoHash so that I would not have to encode that conversion all over my client code.
