### PR TITLE
fix geohash's comparison according to base32 encoded comparison

### DIFF
--- a/src/main/java/ch/hsr/geohash/GeoHash.java
+++ b/src/main/java/ch/hsr/geohash/GeoHash.java
@@ -514,6 +514,11 @@ public final class GeoHash implements Comparable<GeoHash>, Serializable {
 
 	@Override
 	public int compareTo(GeoHash o) {
-		return new Long(bits).compareTo(o.bits);
+		int bitsCmp = Long.compare(bits ^ FIRST_BIT_FLAGGED, o.bits ^ FIRST_BIT_FLAGGED);
+		if (bitsCmp != 0){
+			return bitsCmp;
+		} else {
+			return Integer.compare(significantBits, o.significantBits);
+		}
 	}
 }

--- a/src/test/java/ch/hsr/geohash/GeoHashTest.java
+++ b/src/test/java/ch/hsr/geohash/GeoHashTest.java
@@ -536,4 +536,28 @@ public class GeoHashTest {
 		assertEquals(steps, lonLess + latLess + latMore + lonMore + inBbox - latLessLonMore - latMoreLonLess - 1);
 
 	}
+
+	@Test
+	public void testCompareTo() {
+		GeoHash prevHash = null;
+		for (int i = 0; i < 1000000; i++) {
+			double latitude = rand.nextDouble() * 180 - 90;
+			double longitude = rand.nextDouble() * 360 - 180;
+			int numberOfBits = rand.nextInt(6) * 10 + 10;
+			GeoHash hash = GeoHash.withBitPrecision(latitude, longitude, numberOfBits);
+			if (i >= 1) {
+				String prevHashBase32 = prevHash.toBase32();
+				String hashBase32 = hash.toBase32();
+				String errorMessage = String.format("prev: %s, cur: %s", prevHashBase32, hashBase32);
+				if (prevHashBase32.compareTo(hashBase32) < 0) {
+					assertTrue(errorMessage, prevHash.compareTo(hash) < 0);
+				} else if (prevHashBase32.compareTo(hashBase32) > 0) {
+					assertTrue(errorMessage, prevHash.compareTo(hash) > 0);
+				} else {
+					assertTrue(errorMessage, prevHash.compareTo(hash) == 0);
+				}
+			}
+			prevHash = hash;
+		}
+	}
 }


### PR DESCRIPTION
There are differences between GeoHash's comparison and base32 encoded comparison.
And I fixed GeoHash's comparison method according to base32 encoded comparison method.