### PR TITLE
change ord to use unsigned >>> shift

### DIFF
--- a/src/main/java/ch/hsr/geohash/GeoHash.java
+++ b/src/main/java/ch/hsr/geohash/GeoHash.java
@@ -192,7 +192,7 @@ public final class GeoHash implements Comparable<GeoHash>, Serializable {
 
 	public long ord() {
 		int insignificantBits = 64 - significantBits;
-		return bits >> insignificantBits;
+		return bits >>> insignificantBits;
 	}
 
 	/**


### PR DESCRIPTION
Change the right shift to unsigned. Binary geohash should never be negative / two's compliment breaks it.

Repro -> 
geo = GeoHash(-36.919550434870125,174.71024582237604,7)