### PR TITLE
GeoHash.ord() should always return a positive long value.

### DIFF
--- a/src/main/java/ch/hsr/geohash/GeoHash.java
+++ b/src/main/java/ch/hsr/geohash/GeoHash.java
@@ -192,7 +192,8 @@ public final class GeoHash implements Comparable<GeoHash>, Serializable {
 
 	public long ord() {
 		int insignificantBits = 64 - significantBits;
-		return bits >> insignificantBits;
+		long bitMask = (1L << significantBits) - 1;
+		return (bits >> insignificantBits) & bitMask;
 	}
 
 	/**

--- a/src/test/java/ch/hsr/geohash/GeoHashTest.java
+++ b/src/test/java/ch/hsr/geohash/GeoHashTest.java
@@ -551,4 +551,13 @@ public class GeoHashTest {
 			prevHash = hash;
 		}
 	}
+
+	@Test
+	public void testOrdIsPositive() {
+		double lat = 40.390943;
+		double lon = 75.9375;
+		GeoHash hash = GeoHash.withCharacterPrecision(lat, lon, 12);
+		assertEquals(0xcf6915015410500l, hash.ord());
+		assertTrue(hash.ord() >= 0);
+	}
 }


### PR DESCRIPTION
Previously, if the highest bit of the geohash was 1 (i.e. coordinates east of Greenwich) GeoHash.ord() would return a negative number.