### PR TITLE
This provides handling of BoundingBoxes which go over the 180-Meridian

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
 language: java
 jdk:
   - openjdk8
-  - openjdk7

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: java
 jdk:
-  - oraclejdk8
+  - openjdk8
   - openjdk7

--- a/src/main/java/ch/hsr/geohash/BoundingBox.java
+++ b/src/main/java/ch/hsr/geohash/BoundingBox.java
@@ -21,8 +21,8 @@ public class BoundingBox implements Serializable {
 	/**
 	 * create a bounding box defined by two coordinates
 	 */
-	public BoundingBox(WGS84Point southWest, WGS84Point northEast) {
-		this(southWest.getLatitude(), northEast.getLatitude(), southWest.getLongitude(), northEast.getLongitude());
+	public BoundingBox(WGS84Point southWestCorner, WGS84Point northEastCorner) {
+		this(southWestCorner.getLatitude(), northEastCorner.getLatitude(), southWestCorner.getLongitude(), northEastCorner.getLongitude());
 	}
 
 	/**
@@ -63,38 +63,38 @@ public class BoundingBox implements Serializable {
 	}
 
 	/**
-	 * Returns the NorthWestPoint of this BoundingBox as a new Point.
+	 * Returns the NorthWestCorner of this BoundingBox as a new Point.
 	 *
 	 * @return
 	 */
-	public WGS84Point getNorthWestPoint() {
+	public WGS84Point getNorthWestCorner() {
 		return new WGS84Point(northLatitude, westLongitude);
 	}
 
 	/**
-	 * Returns the NorthEastPoint of this BoundingBox as a new Point.
+	 * Returns the NorthEastCorner of this BoundingBox as a new Point.
 	 *
 	 * @return
 	 */
-	public WGS84Point getNorthEastPoint() {
+	public WGS84Point getNorthEastCorner() {
 		return new WGS84Point(northLatitude, eastLongitude);
 	}
 
 	/**
-	 * Returns the SouthEastPoint of this BoundingBox as a new Point.
+	 * Returns the SouthEastCorner of this BoundingBox as a new Point.
 	 *
 	 * @return
 	 */
-	public WGS84Point getSouthEastPoint() {
+	public WGS84Point getSouthEastCorner() {
 		return new WGS84Point(southLatitude, eastLongitude);
 	}
 
 	/**
-	 * Returns the SouthWestPoint of this BoundingBox as a new Point.
+	 * Returns the SouthWestCorner of this BoundingBox as a new Point.
 	 *
 	 * @return
 	 */
-	public WGS84Point getSouthWestPoint() {
+	public WGS84Point getSouthWestCorner() {
 		return new WGS84Point(southLatitude, westLongitude);
 	}
 
@@ -173,10 +173,10 @@ public class BoundingBox implements Serializable {
 
 	@Override
 	public String toString() {
-		return getNorthWestPoint() + " -> " + getSouthEastPoint();
+		return getNorthWestCorner() + " -> " + getSouthEastCorner();
 	}
 
-	public WGS84Point getCenterPoint() {
+	public WGS84Point getCenter() {
 		double centerLatitude = (southLatitude + northLatitude) / 2;
 		double centerLongitude = (westLongitude + eastLongitude) / 2;
 

--- a/src/main/java/ch/hsr/geohash/GeoHash.java
+++ b/src/main/java/ch/hsr/geohash/GeoHash.java
@@ -334,7 +334,7 @@ public final class GeoHash implements Comparable<GeoHash>, Serializable {
 	 * If it was built from a base32-{@link String}, this is the center point of
 	 * the bounding box.
 	 */
-	public WGS84Point getPoint() {
+	public WGS84Point getOriginatingPoint() {
 		return point;
 	}
 
@@ -343,8 +343,8 @@ public final class GeoHash implements Comparable<GeoHash>, Serializable {
 	 * the same point that was used to build the hash.
 	 */
 	// TODO: make sure this method works as intented for corner cases!
-	public WGS84Point getBoundingBoxCenterPoint() {
-		return boundingBox.getCenterPoint();
+	public WGS84Point getBoundingBoxCenter() {
+		return boundingBox.getCenter();
 	}
 
 	public BoundingBox getBoundingBox() {
@@ -375,7 +375,7 @@ public final class GeoHash implements Comparable<GeoHash>, Serializable {
 		}
 		hash.bits <<= (MAX_BIT_PRECISION - hash.significantBits);
 		setBoundingBox(hash, latitudeRange, longitudeRange);
-		hash.point = hash.boundingBox.getCenterPoint();
+		hash.point = hash.boundingBox.getCenter();
 		return hash;
 	}
 

--- a/src/main/java/ch/hsr/geohash/GeoHash.java
+++ b/src/main/java/ch/hsr/geohash/GeoHash.java
@@ -182,9 +182,7 @@ public final class GeoHash implements Comparable<GeoHash>, Serializable {
 	}
 
 	private static void setBoundingBox(GeoHash hash, double[] latitudeRange, double[] longitudeRange) {
-		hash.boundingBox = new BoundingBox(new WGS84Point(latitudeRange[0], longitudeRange[0]), new WGS84Point(
-				latitudeRange[1],
-				longitudeRange[1]));
+		hash.boundingBox = new BoundingBox(latitudeRange[0], latitudeRange[1], longitudeRange[0], longitudeRange[1]);
 	}
 
 	public GeoHash next(int step) {

--- a/src/main/java/ch/hsr/geohash/GeoHash.java
+++ b/src/main/java/ch/hsr/geohash/GeoHash.java
@@ -458,10 +458,14 @@ public final class GeoHash implements Comparable<GeoHash>, Serializable {
 	@Override
 	public String toString() {
 		if (significantBits % 5 == 0) {
-			return String.format("%s -> %s -> %s", Long.toBinaryString(bits), boundingBox, toBase32());
+			return String.format("%s -> %s -> %s", padLeft(Long.toBinaryString(bits), 64, "0"), boundingBox, toBase32());
 		} else {
-			return String.format("%s -> %s, bits: %d", Long.toBinaryString(bits), boundingBox, significantBits);
+			return String.format("%s -> %s, bits: %d", padLeft(Long.toBinaryString(bits), 64, "0"), boundingBox, significantBits);
 		}
+	}
+
+	private static String padLeft(String s, int n, String pad) {
+		return String.format("%" + n + "s", s).replace(" ", pad);
 	}
 
 	public String toBinaryString() {

--- a/src/main/java/ch/hsr/geohash/queries/GeoHashBoundingBoxQuery.java
+++ b/src/main/java/ch/hsr/geohash/queries/GeoHashBoundingBoxQuery.java
@@ -87,7 +87,7 @@ public class GeoHashBoundingBoxQuery implements GeoHashQuery, Serializable {
 
 	private void generateSearchHashes(BoundingBox bbox) {
 		int fittingBits = GeoHashSizeTable.numberOfBitsForOverlappingGeoHash(bbox);
-		WGS84Point center = bbox.getCenterPoint();
+		WGS84Point center = bbox.getCenter();
 		GeoHash centerHash = GeoHash.withBitPrecision(center.getLatitude(), center.getLongitude(), fittingBits);
 
 		if (hashContainsBoundingBox(centerHash, bbox)) {
@@ -118,7 +118,7 @@ public class GeoHashBoundingBoxQuery implements GeoHashQuery, Serializable {
 	 * @return
 	 */
 	private boolean hashContainsBoundingBox(GeoHash hash, BoundingBox bbox) {
-		return hash.contains(bbox.getNorthWestPoint()) && hash.contains(bbox.getSouthEastPoint());
+		return hash.contains(bbox.getNorthWestCorner()) && hash.contains(bbox.getSouthEastCorner());
 	}
 
 	@Override

--- a/src/main/java/ch/hsr/geohash/queries/GeoHashCircleQuery.java
+++ b/src/main/java/ch/hsr/geohash/queries/GeoHashCircleQuery.java
@@ -26,20 +26,17 @@ public class GeoHashCircleQuery implements GeoHashQuery, Serializable {
 	private GeoHashBoundingBoxQuery query;
 	private WGS84Point center;
 
-	/**
-	 * create a {@link GeoHashCircleQuery} with the given center point and a
-	 * radius in meters.
-	 */
-	public GeoHashCircleQuery(WGS84Point center, double radius) {
-		this.radius = radius;
-		this.center = center;
-		WGS84Point northEast = VincentyGeodesy.moveInDirection(VincentyGeodesy.moveInDirection(center, 0, radius), 90,
-				radius);
-		WGS84Point southWest = VincentyGeodesy.moveInDirection(VincentyGeodesy.moveInDirection(center, 180, radius),
-				270, radius);
-		BoundingBox bbox = new BoundingBox(northEast, southWest);
-		query = new GeoHashBoundingBoxQuery(bbox);
-	}
+    /**
+     * create a {@link GeoHashCircleQuery} with the given center point and a radius in meters.
+     */
+    public GeoHashCircleQuery(WGS84Point center, double radius) {
+        this.radius = radius;
+        this.center = center;
+        WGS84Point northEast = VincentyGeodesy.moveInDirection(VincentyGeodesy.moveInDirection(center, 0, radius), 90, radius);
+        WGS84Point southWest = VincentyGeodesy.moveInDirection(VincentyGeodesy.moveInDirection(center, 180, radius), 270, radius);
+        BoundingBox bbox = new BoundingBox(southWest, northEast);
+        query = new GeoHashBoundingBoxQuery(bbox);
+    }
 
 	@Override
 	public boolean contains(GeoHash hash) {

--- a/src/main/java/ch/hsr/geohash/queries/GeoHashCircleQuery.java
+++ b/src/main/java/ch/hsr/geohash/queries/GeoHashCircleQuery.java
@@ -26,17 +26,17 @@ public class GeoHashCircleQuery implements GeoHashQuery, Serializable {
 	private GeoHashBoundingBoxQuery query;
 	private WGS84Point center;
 
-    /**
-     * create a {@link GeoHashCircleQuery} with the given center point and a radius in meters.
-     */
-    public GeoHashCircleQuery(WGS84Point center, double radius) {
-        this.radius = radius;
-        this.center = center;
-        WGS84Point northEast = VincentyGeodesy.moveInDirection(VincentyGeodesy.moveInDirection(center, 0, radius), 90, radius);
-        WGS84Point southWest = VincentyGeodesy.moveInDirection(VincentyGeodesy.moveInDirection(center, 180, radius), 270, radius);
-        BoundingBox bbox = new BoundingBox(southWest, northEast);
-        query = new GeoHashBoundingBoxQuery(bbox);
-    }
+	/**
+	 * create a {@link GeoHashCircleQuery} with the given center point and a radius in meters.
+	 */
+	public GeoHashCircleQuery(WGS84Point center, double radius) {
+		this.radius = radius;
+		this.center = center;
+		WGS84Point northEastCorner = VincentyGeodesy.moveInDirection(VincentyGeodesy.moveInDirection(center, 0, radius), 90, radius);
+		WGS84Point southWestCorner = VincentyGeodesy.moveInDirection(VincentyGeodesy.moveInDirection(center, 180, radius), 270, radius);
+		BoundingBox bbox = new BoundingBox(southWestCorner, northEastCorner);
+		query = new GeoHashBoundingBoxQuery(bbox);
+	}
 
 	@Override
 	public boolean contains(GeoHash hash) {

--- a/src/main/java/ch/hsr/geohash/util/BoundingBoxGeoHashIterator.java
+++ b/src/main/java/ch/hsr/geohash/util/BoundingBoxGeoHashIterator.java
@@ -15,7 +15,7 @@ public class BoundingBoxGeoHashIterator implements Iterator<GeoHash> {
 
 	public BoundingBoxGeoHashIterator(TwoGeoHashBoundingBox bbox) {
 		boundingBox = bbox;
-		current = bbox.getSouthEast();
+		current = bbox.getSouthWest();
 	}
 
 	public TwoGeoHashBoundingBox getBoundingBox() {
@@ -24,7 +24,7 @@ public class BoundingBoxGeoHashIterator implements Iterator<GeoHash> {
 
 	@Override
 	public boolean hasNext() {
-		return current.compareTo(boundingBox.getNorthWest()) <= 0;
+		return current.compareTo(boundingBox.getNorthEast()) <= 0;
 	}
 
 	@Override

--- a/src/main/java/ch/hsr/geohash/util/BoundingBoxGeoHashIterator.java
+++ b/src/main/java/ch/hsr/geohash/util/BoundingBoxGeoHashIterator.java
@@ -15,7 +15,7 @@ public class BoundingBoxGeoHashIterator implements Iterator<GeoHash> {
 
 	public BoundingBoxGeoHashIterator(TwoGeoHashBoundingBox bbox) {
 		boundingBox = bbox;
-		current = bbox.getSouthWest();
+		current = bbox.getSouthWestCorner();
 	}
 
 	public TwoGeoHashBoundingBox getBoundingBox() {
@@ -24,7 +24,7 @@ public class BoundingBoxGeoHashIterator implements Iterator<GeoHash> {
 
 	@Override
 	public boolean hasNext() {
-		return current.compareTo(boundingBox.getNorthEast()) <= 0;
+		return current.compareTo(boundingBox.getNorthEastCorner()) <= 0;
 	}
 
 	@Override
@@ -34,7 +34,7 @@ public class BoundingBoxGeoHashIterator implements Iterator<GeoHash> {
 			throw new NoSuchElementException();
 		}
 		current = rv.next();
-		while (hasNext() && !boundingBox.getBoundingBox().contains(current.getPoint())) {
+		while (hasNext() && !boundingBox.getBoundingBox().contains(current.getOriginatingPoint())) {
 			current = current.next();
 		}
 		return rv;

--- a/src/main/java/ch/hsr/geohash/util/BoundingBoxGeoHashIterator.java
+++ b/src/main/java/ch/hsr/geohash/util/BoundingBoxGeoHashIterator.java
@@ -14,8 +14,8 @@ public class BoundingBoxGeoHashIterator implements Iterator<GeoHash> {
 	private GeoHash current;
 
 	public BoundingBoxGeoHashIterator(TwoGeoHashBoundingBox bbox) {
-		this.boundingBox = bbox;
-		this.current = bbox.getBottomLeft();
+		boundingBox = bbox;
+		current = bbox.getSouthEast();
 	}
 
 	public TwoGeoHashBoundingBox getBoundingBox() {
@@ -24,7 +24,7 @@ public class BoundingBoxGeoHashIterator implements Iterator<GeoHash> {
 
 	@Override
 	public boolean hasNext() {
-		return current.compareTo(boundingBox.getTopRight()) <= 0;
+		return current.compareTo(boundingBox.getNorthWest()) <= 0;
 	}
 
 	@Override

--- a/src/main/java/ch/hsr/geohash/util/BoundingBoxSampler.java
+++ b/src/main/java/ch/hsr/geohash/util/BoundingBoxSampler.java
@@ -23,7 +23,7 @@ public class BoundingBoxSampler {
 	 */
 	public BoundingBoxSampler(TwoGeoHashBoundingBox bbox) {
 		boundingBox = bbox;
-		long maxSamplesLong = GeoHash.stepsBetween(bbox.getSouthEast(), bbox.getNorthWest());
+		long maxSamplesLong = GeoHash.stepsBetween(bbox.getSouthWest(), bbox.getNorthEast());
 		if (maxSamplesLong > Integer.MAX_VALUE) {
 			throw new IllegalArgumentException("This bounding box is too big too sample using this algorithm");
 		}
@@ -51,7 +51,7 @@ public class BoundingBoxSampler {
 			idx = rand.nextInt(maxSamples + 1);
 		}
 		alreadyUsed.add(idx);
-		GeoHash gh = boundingBox.getSouthEast().next(idx);
+		GeoHash gh = boundingBox.getSouthWest().next(idx);
 		if (!boundingBox.getBoundingBox().contains(gh.getPoint())) {
 			return next();
 		}

--- a/src/main/java/ch/hsr/geohash/util/BoundingBoxSampler.java
+++ b/src/main/java/ch/hsr/geohash/util/BoundingBoxSampler.java
@@ -22,8 +22,8 @@ public class BoundingBoxSampler {
 	 *             exceeds Integer.MAX_VALUE
 	 */
 	public BoundingBoxSampler(TwoGeoHashBoundingBox bbox) {
-		this.boundingBox = bbox;
-		long maxSamplesLong = GeoHash.stepsBetween(bbox.getBottomLeft(), bbox.getTopRight());
+		boundingBox = bbox;
+		long maxSamplesLong = GeoHash.stepsBetween(bbox.getSouthEast(), bbox.getNorthWest());
 		if (maxSamplesLong > Integer.MAX_VALUE) {
 			throw new IllegalArgumentException("This bounding box is too big too sample using this algorithm");
 		}
@@ -51,7 +51,7 @@ public class BoundingBoxSampler {
 			idx = rand.nextInt(maxSamples + 1);
 		}
 		alreadyUsed.add(idx);
-		GeoHash gh = boundingBox.getBottomLeft().next(idx);
+		GeoHash gh = boundingBox.getSouthEast().next(idx);
 		if (!boundingBox.getBoundingBox().contains(gh.getPoint())) {
 			return next();
 		}

--- a/src/main/java/ch/hsr/geohash/util/BoundingBoxSampler.java
+++ b/src/main/java/ch/hsr/geohash/util/BoundingBoxSampler.java
@@ -23,7 +23,7 @@ public class BoundingBoxSampler {
 	 */
 	public BoundingBoxSampler(TwoGeoHashBoundingBox bbox) {
 		boundingBox = bbox;
-		long maxSamplesLong = GeoHash.stepsBetween(bbox.getSouthWest(), bbox.getNorthEast());
+		long maxSamplesLong = GeoHash.stepsBetween(bbox.getSouthWestCorner(), bbox.getNorthEastCorner());
 		if (maxSamplesLong > Integer.MAX_VALUE) {
 			throw new IllegalArgumentException("This bounding box is too big too sample using this algorithm");
 		}
@@ -32,7 +32,7 @@ public class BoundingBoxSampler {
 
 	public BoundingBoxSampler(TwoGeoHashBoundingBox bbox, long seed) {
 		this(bbox);
-		this.rand = new Random(seed);
+		rand = new Random(seed);
 	}
 
 	public TwoGeoHashBoundingBox getBoundingBox() {
@@ -51,8 +51,8 @@ public class BoundingBoxSampler {
 			idx = rand.nextInt(maxSamples + 1);
 		}
 		alreadyUsed.add(idx);
-		GeoHash gh = boundingBox.getSouthWest().next(idx);
-		if (!boundingBox.getBoundingBox().contains(gh.getPoint())) {
+		GeoHash gh = boundingBox.getSouthWestCorner().next(idx);
+		if (!boundingBox.getBoundingBox().contains(gh.getOriginatingPoint())) {
 			return next();
 		}
 		return gh;

--- a/src/main/java/ch/hsr/geohash/util/TwoGeoHashBoundingBox.java
+++ b/src/main/java/ch/hsr/geohash/util/TwoGeoHashBoundingBox.java
@@ -8,51 +8,49 @@ import ch.hsr.geohash.GeoHash;
  */
 public class TwoGeoHashBoundingBox {
 	private BoundingBox boundingBox;
-	private GeoHash bottomLeft;
-	private GeoHash topRight;
+	private GeoHash southEast;
+	private GeoHash northWest;
 
 	public static TwoGeoHashBoundingBox withCharacterPrecision(BoundingBox bbox, int numberOfCharacters) {
-		GeoHash bottomLeft = GeoHash.withCharacterPrecision(bbox.getMinLat(), bbox.getMinLon(), numberOfCharacters);
-		GeoHash topRight = GeoHash.withCharacterPrecision(bbox.getMaxLat(), bbox.getMaxLon(), numberOfCharacters);
+		GeoHash bottomLeft = GeoHash.withCharacterPrecision(bbox.getSouthLatitude(), bbox.getWestLongitude(), numberOfCharacters);
+		GeoHash topRight = GeoHash.withCharacterPrecision(bbox.getNorthLatitude(), bbox.getEastLongitude(), numberOfCharacters);
 		return new TwoGeoHashBoundingBox(bottomLeft, topRight);
 	}
 
 	public static TwoGeoHashBoundingBox withBitPrecision(BoundingBox bbox, int numberOfBits) {
-		GeoHash bottomLeft = GeoHash.withBitPrecision(bbox.getMinLat(), bbox.getMinLon(), numberOfBits);
-		GeoHash topRight = GeoHash.withBitPrecision(bbox.getMaxLat(), bbox.getMaxLon(), numberOfBits);
+		GeoHash bottomLeft = GeoHash.withBitPrecision(bbox.getSouthLatitude(), bbox.getWestLongitude(), numberOfBits);
+		GeoHash topRight = GeoHash.withBitPrecision(bbox.getNorthLatitude(), bbox.getEastLongitude(), numberOfBits);
 		return new TwoGeoHashBoundingBox(bottomLeft, topRight);
 	}
 
 	public static TwoGeoHashBoundingBox fromBase32(String base32) {
-		String bottomLeft = base32.substring(0, 7);
-		String topRight = base32.substring(7);
-		return new TwoGeoHashBoundingBox(GeoHash.fromGeohashString(bottomLeft), GeoHash.fromGeohashString(topRight));
+		String southWestBase32 = base32.substring(0, 7);
+		String northEastBase32 = base32.substring(7);
+		return new TwoGeoHashBoundingBox(GeoHash.fromGeohashString(southWestBase32), GeoHash.fromGeohashString(northEastBase32));
 	}
 
-	public TwoGeoHashBoundingBox(GeoHash bottomLeft, GeoHash topRight) {
-		if (bottomLeft.significantBits() != topRight.significantBits()) {
-			throw new IllegalArgumentException(
-					"Does it make sense to iterate between hashes that have different precisions?");
+	public TwoGeoHashBoundingBox(GeoHash southEast, GeoHash northWest) {
+		if (southEast.significantBits() != northWest.significantBits()) {
+			throw new IllegalArgumentException("Does it make sense to iterate between hashes that have different precisions?");
 		}
-		this.bottomLeft = GeoHash.fromLongValue(bottomLeft.longValue(), bottomLeft.significantBits());
-		this.topRight = GeoHash.fromLongValue(topRight.longValue(), topRight.significantBits());
-		this.boundingBox = this.bottomLeft.getBoundingBox();
-		this.boundingBox.expandToInclude(this.topRight.getBoundingBox());
+		this.southEast = GeoHash.fromLongValue(southEast.longValue(), southEast.significantBits());
+		this.northWest = GeoHash.fromLongValue(northWest.longValue(), northWest.significantBits());
+		boundingBox = new BoundingBox(southEast.getBoundingBox().getSouthLatitude(), northWest.getBoundingBox().getNorthLatitude(), northWest.getBoundingBox().getWestLongitude(), southEast.getBoundingBox().getEastLongitude());
 	}
 
 	public BoundingBox getBoundingBox() {
 		return boundingBox;
 	}
 
-	public GeoHash getBottomLeft() {
-		return bottomLeft;
+	public GeoHash getSouthEast() {
+		return southEast;
 	}
 
-	public GeoHash getTopRight() {
-		return topRight;
+	public GeoHash getNorthWest() {
+		return northWest;
 	}
 
 	public String toBase32() {
-		return bottomLeft.toBase32() + topRight.toBase32();
+		return southEast.toBase32() + northWest.toBase32();
 	}
 }

--- a/src/main/java/ch/hsr/geohash/util/TwoGeoHashBoundingBox.java
+++ b/src/main/java/ch/hsr/geohash/util/TwoGeoHashBoundingBox.java
@@ -7,44 +7,44 @@ import ch.hsr.geohash.GeoHash;
  * Created by IntelliJ IDEA. User: kevin Date: Jan 17, 2011 Time: 12:03:47 PM
  */
 public class TwoGeoHashBoundingBox {
-    private BoundingBox boundingBox;
-    private GeoHash southWest;
-    private GeoHash northEast;
+	private BoundingBox boundingBox;
+	private GeoHash southWestCorner;
+	private GeoHash northEastCorner;
 
-    public static TwoGeoHashBoundingBox withCharacterPrecision(BoundingBox bbox, int numberOfCharacters) {
-        GeoHash southWest = GeoHash.withCharacterPrecision(bbox.getSouthLatitude(), bbox.getWestLongitude(), numberOfCharacters);
-        GeoHash northEast = GeoHash.withCharacterPrecision(bbox.getNorthLatitude(), bbox.getEastLongitude(), numberOfCharacters);
-        return new TwoGeoHashBoundingBox(southWest, northEast);
-    }
+	public static TwoGeoHashBoundingBox withCharacterPrecision(BoundingBox bbox, int numberOfCharacters) {
+		GeoHash southWestCorner = GeoHash.withCharacterPrecision(bbox.getSouthLatitude(), bbox.getWestLongitude(), numberOfCharacters);
+		GeoHash northEastCorner = GeoHash.withCharacterPrecision(bbox.getNorthLatitude(), bbox.getEastLongitude(), numberOfCharacters);
+		return new TwoGeoHashBoundingBox(southWestCorner, northEastCorner);
+	}
 
-    public static TwoGeoHashBoundingBox withBitPrecision(BoundingBox bbox, int numberOfBits) {
-        GeoHash southWest = GeoHash.withBitPrecision(bbox.getSouthLatitude(), bbox.getWestLongitude(), numberOfBits);
-        GeoHash northEast = GeoHash.withBitPrecision(bbox.getNorthLatitude(), bbox.getEastLongitude(), numberOfBits);
-        return new TwoGeoHashBoundingBox(southWest, northEast);
-    }
+	public static TwoGeoHashBoundingBox withBitPrecision(BoundingBox bbox, int numberOfBits) {
+		GeoHash southWestCorner = GeoHash.withBitPrecision(bbox.getSouthLatitude(), bbox.getWestLongitude(), numberOfBits);
+		GeoHash northEastCorner = GeoHash.withBitPrecision(bbox.getNorthLatitude(), bbox.getEastLongitude(), numberOfBits);
+		return new TwoGeoHashBoundingBox(southWestCorner, northEastCorner);
+	}
 
-    public TwoGeoHashBoundingBox(GeoHash southWest, GeoHash northEast) {
-        if (southWest.significantBits() != northEast.significantBits()) {
-            throw new IllegalArgumentException("Does it make sense to iterate between hashes that have different precisions?");
-        }
-        this.southWest = GeoHash.fromLongValue(southWest.longValue(), southWest.significantBits());
-        this.northEast = GeoHash.fromLongValue(northEast.longValue(), northEast.significantBits());
-        boundingBox = new BoundingBox(southWest.getBoundingBox().getSouthLatitude(), northEast.getBoundingBox().getNorthLatitude(), southWest.getBoundingBox().getWestLongitude(), northEast.getBoundingBox().getEastLongitude());
-    }
+	public TwoGeoHashBoundingBox(GeoHash southWestCorner, GeoHash northEastCorner) {
+		if (southWestCorner.significantBits() != northEastCorner.significantBits()) {
+			throw new IllegalArgumentException("Does it make sense to iterate between hashes that have different precisions?");
+		}
+		this.southWestCorner = GeoHash.fromLongValue(southWestCorner.longValue(), southWestCorner.significantBits());
+		this.northEastCorner = GeoHash.fromLongValue(northEastCorner.longValue(), northEastCorner.significantBits());
+		boundingBox = new BoundingBox(southWestCorner.getBoundingBox().getSouthLatitude(), northEastCorner.getBoundingBox().getNorthLatitude(), southWestCorner.getBoundingBox().getWestLongitude(), northEastCorner.getBoundingBox().getEastLongitude());
+	}
 
-    public BoundingBox getBoundingBox() {
-        return boundingBox;
-    }
+	public BoundingBox getBoundingBox() {
+		return boundingBox;
+	}
 
-    public GeoHash getSouthWest() {
-        return southWest;
-    }
+	public GeoHash getSouthWestCorner() {
+		return southWestCorner;
+	}
 
-    public GeoHash getNorthEast() {
-        return northEast;
-    }
+	public GeoHash getNorthEastCorner() {
+		return northEastCorner;
+	}
 
-    public String toBase32() {
-        return southWest.toBase32() + northEast.toBase32();
-    }
+	public String toBase32() {
+		return southWestCorner.toBase32() + northEastCorner.toBase32();
+	}
 }

--- a/src/main/java/ch/hsr/geohash/util/TwoGeoHashBoundingBox.java
+++ b/src/main/java/ch/hsr/geohash/util/TwoGeoHashBoundingBox.java
@@ -7,50 +7,50 @@ import ch.hsr.geohash.GeoHash;
  * Created by IntelliJ IDEA. User: kevin Date: Jan 17, 2011 Time: 12:03:47 PM
  */
 public class TwoGeoHashBoundingBox {
-	private BoundingBox boundingBox;
-	private GeoHash southEast;
-	private GeoHash northWest;
+    private BoundingBox boundingBox;
+    private GeoHash southWest;
+    private GeoHash northEast;
 
-	public static TwoGeoHashBoundingBox withCharacterPrecision(BoundingBox bbox, int numberOfCharacters) {
-		GeoHash bottomLeft = GeoHash.withCharacterPrecision(bbox.getSouthLatitude(), bbox.getWestLongitude(), numberOfCharacters);
-		GeoHash topRight = GeoHash.withCharacterPrecision(bbox.getNorthLatitude(), bbox.getEastLongitude(), numberOfCharacters);
-		return new TwoGeoHashBoundingBox(bottomLeft, topRight);
-	}
+    public static TwoGeoHashBoundingBox withCharacterPrecision(BoundingBox bbox, int numberOfCharacters) {
+        GeoHash southWest = GeoHash.withCharacterPrecision(bbox.getSouthLatitude(), bbox.getWestLongitude(), numberOfCharacters);
+        GeoHash northEast = GeoHash.withCharacterPrecision(bbox.getNorthLatitude(), bbox.getEastLongitude(), numberOfCharacters);
+        return new TwoGeoHashBoundingBox(southWest, northEast);
+    }
 
-	public static TwoGeoHashBoundingBox withBitPrecision(BoundingBox bbox, int numberOfBits) {
-		GeoHash bottomLeft = GeoHash.withBitPrecision(bbox.getSouthLatitude(), bbox.getWestLongitude(), numberOfBits);
-		GeoHash topRight = GeoHash.withBitPrecision(bbox.getNorthLatitude(), bbox.getEastLongitude(), numberOfBits);
-		return new TwoGeoHashBoundingBox(bottomLeft, topRight);
-	}
+    public static TwoGeoHashBoundingBox withBitPrecision(BoundingBox bbox, int numberOfBits) {
+        GeoHash southWest = GeoHash.withBitPrecision(bbox.getSouthLatitude(), bbox.getWestLongitude(), numberOfBits);
+        GeoHash northEast = GeoHash.withBitPrecision(bbox.getNorthLatitude(), bbox.getEastLongitude(), numberOfBits);
+        return new TwoGeoHashBoundingBox(southWest, northEast);
+    }
 
-	public static TwoGeoHashBoundingBox fromBase32(String base32) {
-		String southWestBase32 = base32.substring(0, 7);
-		String northEastBase32 = base32.substring(7);
-		return new TwoGeoHashBoundingBox(GeoHash.fromGeohashString(southWestBase32), GeoHash.fromGeohashString(northEastBase32));
-	}
+    public static TwoGeoHashBoundingBox fromBase32(String base32) {
+        String southWestBase32 = base32.substring(0, 7);
+        String northEastBase32 = base32.substring(7);
+        return new TwoGeoHashBoundingBox(GeoHash.fromGeohashString(southWestBase32), GeoHash.fromGeohashString(northEastBase32));
+    }
 
-	public TwoGeoHashBoundingBox(GeoHash southEast, GeoHash northWest) {
-		if (southEast.significantBits() != northWest.significantBits()) {
-			throw new IllegalArgumentException("Does it make sense to iterate between hashes that have different precisions?");
-		}
-		this.southEast = GeoHash.fromLongValue(southEast.longValue(), southEast.significantBits());
-		this.northWest = GeoHash.fromLongValue(northWest.longValue(), northWest.significantBits());
-		boundingBox = new BoundingBox(southEast.getBoundingBox().getSouthLatitude(), northWest.getBoundingBox().getNorthLatitude(), northWest.getBoundingBox().getWestLongitude(), southEast.getBoundingBox().getEastLongitude());
-	}
+    public TwoGeoHashBoundingBox(GeoHash southWest, GeoHash northEast) {
+        if (southWest.significantBits() != northEast.significantBits()) {
+            throw new IllegalArgumentException("Does it make sense to iterate between hashes that have different precisions?");
+        }
+        this.southWest = GeoHash.fromLongValue(southWest.longValue(), southWest.significantBits());
+        this.northEast = GeoHash.fromLongValue(northEast.longValue(), northEast.significantBits());
+        boundingBox = new BoundingBox(southWest.getBoundingBox().getSouthLatitude(), northEast.getBoundingBox().getNorthLatitude(), southWest.getBoundingBox().getWestLongitude(), northEast.getBoundingBox().getEastLongitude());
+    }
 
-	public BoundingBox getBoundingBox() {
-		return boundingBox;
-	}
+    public BoundingBox getBoundingBox() {
+        return boundingBox;
+    }
 
-	public GeoHash getSouthEast() {
-		return southEast;
-	}
+    public GeoHash getSouthWest() {
+        return southWest;
+    }
 
-	public GeoHash getNorthWest() {
-		return northWest;
-	}
+    public GeoHash getNorthEast() {
+        return northEast;
+    }
 
-	public String toBase32() {
-		return southEast.toBase32() + northWest.toBase32();
-	}
+    public String toBase32() {
+        return southWest.toBase32() + northEast.toBase32();
+    }
 }

--- a/src/main/java/ch/hsr/geohash/util/TwoGeoHashBoundingBox.java
+++ b/src/main/java/ch/hsr/geohash/util/TwoGeoHashBoundingBox.java
@@ -23,12 +23,6 @@ public class TwoGeoHashBoundingBox {
         return new TwoGeoHashBoundingBox(southWest, northEast);
     }
 
-    public static TwoGeoHashBoundingBox fromBase32(String base32) {
-        String southWestBase32 = base32.substring(0, 7);
-        String northEastBase32 = base32.substring(7);
-        return new TwoGeoHashBoundingBox(GeoHash.fromGeohashString(southWestBase32), GeoHash.fromGeohashString(northEastBase32));
-    }
-
     public TwoGeoHashBoundingBox(GeoHash southWest, GeoHash northEast) {
         if (southWest.significantBits() != northEast.significantBits()) {
             throw new IllegalArgumentException("Does it make sense to iterate between hashes that have different precisions?");

--- a/src/test/java/ch/hsr/geohash/BoundingBoxTest.java
+++ b/src/test/java/ch/hsr/geohash/BoundingBoxTest.java
@@ -21,12 +21,16 @@ public class BoundingBoxTest {
 	private BoundingBox a;
 	private BoundingBox b;
 	private BoundingBox c;
+	private BoundingBox d;
+	private BoundingBox e;
 
 	@Before
 	public void setUp() {
-		a = new BoundingBox(new WGS84Point(30, 20), new WGS84Point(21, 31));
+		a = new BoundingBox(new WGS84Point(21, 20), new WGS84Point(30, 31));
 		b = new BoundingBox(a);
-		c = new BoundingBox(new WGS84Point(45, -170), new WGS84Point(-45, 170));
+		c = new BoundingBox(new WGS84Point(-45, -170), new WGS84Point(45, 170));
+		d = new BoundingBox(new WGS84Point(-45, 170), new WGS84Point(-45, -170));
+		e = new BoundingBox(d);
 	}
 
 	@Test
@@ -40,13 +44,24 @@ public class BoundingBoxTest {
 		assertEquals(a, b);
 		assertEquals(b, a);
 		assertFalse(a.equals(c));
+		assertEquals(d, e);
+		assertEquals(e, d);
+		assertFalse(c.equals(d));
+		assertFalse(c.equals(a));
 	}
 
 	@Test
 	public void testContains() {
-		BoundingBox bbox = new BoundingBox(45, 46, 121, 120);
+		BoundingBox bbox = new BoundingBox(45, 46, 120, 121);
 		assertContains(bbox, new WGS84Point(45.5, 120.5));
 		assertNotContains(bbox, new WGS84Point(90, 90));
+
+		// Testing bounding box over 180-Meridian
+		bbox = new BoundingBox(45, 46, 170, -170);
+		assertContains(bbox, new WGS84Point(45.5, 175));
+		assertContains(bbox, new WGS84Point(45.5, -175));
+		assertNotContains(bbox, new WGS84Point(45.5, -165));
+		assertNotContains(bbox, new WGS84Point(45.5, 165));
 	}
 
 	@Test
@@ -57,9 +72,14 @@ public class BoundingBoxTest {
 		bbox = new BoundingBox(-45, 45, -22.5, 30);
 		assertHeightIs(bbox, 90);
 		assertWidthIs(bbox, 52.5);
-		bbox = new BoundingBox(-44, -46.1, -127.2, -128);
+		bbox = new BoundingBox(-46.1, -44, -128, -127.2);
 		assertHeightIs(bbox, 2.1);
 		assertWidthIs(bbox, 0.8);
+
+		// Testing bounding box over 180-Meridian
+		bbox = new BoundingBox(45, 90, 170, -170);
+		assertHeightIs(bbox, 45);
+		assertWidthIs(bbox, 20);
 	}
 
 	private void assertWidthIs(BoundingBox bbox, double width) {
@@ -72,9 +92,24 @@ public class BoundingBoxTest {
 
 	@Test
 	public void testIntersects() {
-		BoundingBox bbox = new BoundingBox(10, -10, 41, 40);
-		assertIntersects(bbox, new BoundingBox(5, -15, 40.5, 43));
-		assertDoesNotIntersect(bbox, new BoundingBox(5, -15, 42, 43));
+		BoundingBox bbox = new BoundingBox(-10, 10, 40, 41);
+		assertIntersects(bbox, new BoundingBox(-15, 5, 40.5, 43));
+		assertDoesNotIntersect(bbox, new BoundingBox(-15, 5, 42, 43));
+
+		// Testing bounding box over 180-Meridian
+		bbox = new BoundingBox(45, 90, 170, -170);
+		assertIntersects(bbox, new BoundingBox(50, 55, 175, 176));
+		assertIntersects(bbox, new BoundingBox(50, 55, 160, 176));
+		assertIntersects(bbox, new BoundingBox(50, 55, -175, -176));
+		assertIntersects(bbox, new BoundingBox(50, 55, -160, -176));
+		assertIntersects(bbox, new BoundingBox(50, 55, 175, -175));
+		assertIntersects(bbox, new BoundingBox(50, 55, -175, 175));
+
+		assertDoesNotIntersect(bbox, new BoundingBox(-15, 5, 42, 43));
+		assertDoesNotIntersect(bbox, new BoundingBox(-15, 5, 175, 176));
+		assertDoesNotIntersect(bbox, new BoundingBox(-15, 5, 175, -175));
+		assertDoesNotIntersect(bbox, new BoundingBox(50, 55, 160, 169));
+		assertDoesNotIntersect(bbox, new BoundingBox(50, 55, -169, -160));
 	}
 
 	private void assertDoesNotIntersect(BoundingBox bbox, BoundingBox boundingBox) {

--- a/src/test/java/ch/hsr/geohash/GeoHashBoundingBoxSearchTest.java
+++ b/src/test/java/ch/hsr/geohash/GeoHashBoundingBoxSearchTest.java
@@ -21,29 +21,46 @@ public class GeoHashBoundingBoxSearchTest {
 	@Test
 	public void testSeveralBoundingBoxes() {
 		checkSearchYieldsCorrectNumberOfHashes(40.2090980098, 40.21982983232432, -22.523432424324, -22.494234232442);
-		checkSearchYieldsCorrectNumberOfHashes(41.23452234, 40.09872762, 31.23432, 30.0113312322);
-		checkSearchYieldsCorrectHashes(47.447907, 47.300200, 8.760941, 8.471276, "u0qj");
+		checkSearchYieldsCorrectNumberOfHashes(40.09872762, 41.23452234, 30.0113312322, 31.23432);
+
+		checkSearchYieldsCorrectHashes(47.300200, 47.447907, 8.471276, 8.760941, "u0qj");
 		checkSearchYieldsCorrectHashes(47.157502, 47.329727, 8.562244, 8.859215, "u0qj", "u0qm", "u0qh", "u0qk");
+
+		// Testing bounding box over 180-Meridian
+		checkSearchYieldsCorrectNumberOfHashes(40.2090980098, 40.21982983232432, 170.523432424324, -170.494234232442);
+		checkSearchYieldsCorrectNumberOfHashes(40.2090980098, 40.21982983232432, 170.523432424324, 160.494234232442);
+
+		checkSearchYieldsCorrectHashes(40.2090980098, 40.21982983232432, 170.523432424324, -170.494234232442, "xz", "8p");
+		checkSearchYieldsCorrectBinaryHashes(47.157502, 47.329727, 179.062244, -179.859215, "1111101010101111", "010100000000010100000", "010100000000010100010");
+
+		// Check duplicate handling
+		checkSearchYieldsCorrectBinaryHashes(47.157502, 47.329727, 179.062244, 160, "");
+		checkSearchYieldsCorrectBinaryHashes(47.157502, 47.329727, 179.062244, -1, "01", "1111101010101111");
 	}
 
-	private void checkSearchYieldsCorrectNumberOfHashes(double minLat, double maxLat, double minLon, double maxLon) {
-		GeoHashQuery search = new GeoHashBoundingBoxQuery(new BoundingBox(minLat, maxLat, minLon, maxLon));
+	private void checkSearchYieldsCorrectNumberOfHashes(double southLat, double northLat, double westLon, double eastLon) {
+		GeoHashQuery search = new GeoHashBoundingBoxQuery(new BoundingBox(southLat, northLat, westLon, eastLon));
 		assertRightNumberOfSearchHashes(search);
 	}
 
-	private void checkSearchYieldsCorrectHashes(double minLat, double maxLat, double minLon, double maxLon,
-			String... hashes) {
-		GeoHashQuery search = new GeoHashBoundingBoxQuery(new BoundingBox(minLat, maxLat, minLon, maxLon));
+	private void checkSearchYieldsCorrectHashes(double southLat, double northLat, double westLon, double eastLon, String... hashes) {
+		GeoHashQuery search = new GeoHashBoundingBoxQuery(new BoundingBox(southLat, northLat, westLon, eastLon));
 		assertEquals(hashes.length, search.getSearchHashes().size());
 		for (String expectedHash : hashes) {
-			assertTrue("search hashes should contain " + expectedHash + " is: " + search, search.getSearchHashes()
-					.contains(
-							GeoHash.fromGeohashString(expectedHash)));
+			assertTrue("search hashes should contain '" + expectedHash + "':'" + GeoHash.fromGeohashString(expectedHash) + "'. Saved hashes:\n " + search, search.getSearchHashes().contains(GeoHash.fromGeohashString(expectedHash)));
+		}
+	}
+
+	private void checkSearchYieldsCorrectBinaryHashes(double southLat, double northLat, double westLon, double eastLon, String... hashes) {
+		GeoHashQuery search = new GeoHashBoundingBoxQuery(new BoundingBox(southLat, northLat, westLon, eastLon));
+		assertEquals(hashes.length, search.getSearchHashes().size());
+		for (String expectedHash : hashes) {
+			assertTrue("search hashes should contain '" + expectedHash + "':'" + GeoHash.fromBinaryString(expectedHash) + "'. Saved hashes:\n " + search, search.getSearchHashes().contains(GeoHash.fromBinaryString(expectedHash)));
 		}
 	}
 
 	private void assertRightNumberOfSearchHashes(GeoHashQuery search) {
 		int size = search.getSearchHashes().size();
-		assertTrue(size == 1 || size == 2 || size == 4);
+		assertTrue(size <= 8 && size > 0);
 	}
 }

--- a/src/test/java/ch/hsr/geohash/GeoHashCircleQueryTest.java
+++ b/src/test/java/ch/hsr/geohash/GeoHashCircleQueryTest.java
@@ -1,5 +1,6 @@
 package ch.hsr.geohash;
 
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
@@ -16,8 +17,30 @@ public class GeoHashCircleQueryTest {
 		WGS84Point test1 = new WGS84Point(39.8648866576058, 116.378465869303);
 		// the distance between center and test2 is about 510 meters
 		WGS84Point test2 = new WGS84Point(39.8664787092599, 116.378552856158);
+		// the distance between center and test2 is about 600 meters
+		WGS84Point test3 = new WGS84Point(39.8786787092599, 116.378552856158);
 
 		assertTrue(query.contains(test1));
 		assertTrue(query.contains(test2));
+		assertFalse(query.contains(test3));
+	}
+
+	@Test
+	public void test180MeridianCircleQuery() throws Exception {
+		// Test query over 180-Meridian
+		WGS84Point center = new WGS84Point(39.86391280373075, 179.98356590048701);
+		GeoHashCircleQuery query = new GeoHashCircleQuery(center, 3000);
+
+		WGS84Point test1 = new WGS84Point(39.8648866576058, 180);
+		WGS84Point test2 = new WGS84Point(39.8664787092599, -180);
+		WGS84Point test3 = new WGS84Point(39.8686787092599, -179.9957861565146);
+		WGS84Point test4 = new WGS84Point(39.8686787092599, 179.0057861565146);
+		WGS84Point test5 = new WGS84Point(39.8686787092599, -179.0);
+
+		assertTrue(query.contains(test1));
+		assertTrue(query.contains(test2));
+		assertTrue(query.contains(test3));
+		assertFalse(query.contains(test4));
+		assertFalse(query.contains(test5));
 	}
 }

--- a/src/test/java/ch/hsr/geohash/GeoHashTest.java
+++ b/src/test/java/ch/hsr/geohash/GeoHashTest.java
@@ -502,14 +502,14 @@ public class GeoHashTest {
 			}
 			boolean latIsMore = false;
 			boolean latIsLess = false;
-			if (idx.getPoint().getLatitude() > iterBbox.getMaxLat()) {
+			if (idx.getPoint().getLatitude() > iterBbox.getNorthLatitude()) {
 				latIsMore = true;
 				latMore++;
-			} else if (idx.getPoint().getLatitude() < iterBbox.getMinLat()) {
+			} else if (idx.getPoint().getLatitude() < iterBbox.getSouthLatitude()) {
 				latIsLess = true;
 				latLess++;
 			}
-			if (idx.getPoint().getLongitude() > iterBbox.getMaxLon()) {
+			if (idx.getPoint().getLongitude() > iterBbox.getEastLongitude()) {
 				lonMore++;
 				if (latIsMore) {
 					bothMore++;
@@ -517,7 +517,7 @@ public class GeoHashTest {
 				if (latIsLess) {
 					latLessLonMore++;
 				}
-			} else if (idx.getPoint().getLongitude() < iterBbox.getMinLon()) {
+			} else if (idx.getPoint().getLongitude() < iterBbox.getWestLongitude()) {
 				lonLess++;
 				if (latIsLess) {
 					bothLess++;

--- a/src/test/java/ch/hsr/geohash/GeoHashTest.java
+++ b/src/test/java/ch/hsr/geohash/GeoHashTest.java
@@ -78,7 +78,7 @@ public class GeoHashTest {
 		for (GeoHash gh : RandomGeohashes.fullRange()) {
 			BoundingBox bbox = gh.getBoundingBox();
 			GeoHash decodedHash = GeoHash.fromGeohashString(gh.toBase32());
-			WGS84Point decodedCenter = decodedHash.getBoundingBoxCenterPoint();
+			WGS84Point decodedCenter = decodedHash.getBoundingBoxCenter();
 
 			assertTrue("bbox " + bbox + " should contain the decoded center value " + decodedCenter, bbox
 					.contains(decodedCenter));
@@ -348,8 +348,8 @@ public class GeoHashTest {
 		GeoHash[] adjacentHashes = geohash.getAdjacent();
 		for (GeoHash adjacentHash : adjacentHashes) {
 			assertNotNull(adjacentHash.getBoundingBox());
-			assertNotNull(adjacentHash.getBoundingBoxCenterPoint());
-			assertNotNull(adjacentHash.getPoint());
+			assertNotNull(adjacentHash.getBoundingBoxCenter());
+			assertNotNull(adjacentHash.getOriginatingPoint());
 		}
 	}
 
@@ -405,7 +405,7 @@ public class GeoHashTest {
 	}
 
 	private void printBoundingBox(GeoHash hash) {
-		System.out.println("Bounding Box: \ncenter =" + hash.getBoundingBoxCenterPoint());
+		System.out.println("Bounding Box: \ncenter =" + hash.getBoundingBoxCenter());
 		System.out.print("corners=");
 		System.out.println(hash.getBoundingBox());
 	}
@@ -497,19 +497,19 @@ public class GeoHashTest {
 		while (idx.compareTo(ur) < 0) {
 			idx = idx.next();
 			allHashes++;
-			if (iterBbox.contains(idx.getPoint())) {
+			if (iterBbox.contains(idx.getOriginatingPoint())) {
 				inBbox++;
 			}
 			boolean latIsMore = false;
 			boolean latIsLess = false;
-			if (idx.getPoint().getLatitude() > iterBbox.getNorthLatitude()) {
+			if (idx.getOriginatingPoint().getLatitude() > iterBbox.getNorthLatitude()) {
 				latIsMore = true;
 				latMore++;
-			} else if (idx.getPoint().getLatitude() < iterBbox.getSouthLatitude()) {
+			} else if (idx.getOriginatingPoint().getLatitude() < iterBbox.getSouthLatitude()) {
 				latIsLess = true;
 				latLess++;
 			}
-			if (idx.getPoint().getLongitude() > iterBbox.getEastLongitude()) {
+			if (idx.getOriginatingPoint().getLongitude() > iterBbox.getEastLongitude()) {
 				lonMore++;
 				if (latIsMore) {
 					bothMore++;
@@ -517,7 +517,7 @@ public class GeoHashTest {
 				if (latIsLess) {
 					latLessLonMore++;
 				}
-			} else if (idx.getPoint().getLongitude() < iterBbox.getWestLongitude()) {
+			} else if (idx.getOriginatingPoint().getLongitude() < iterBbox.getWestLongitude()) {
 				lonLess++;
 				if (latIsLess) {
 					bothLess++;

--- a/src/test/java/ch/hsr/geohash/util/BoundingBoxGeoHashIteratorTest.java
+++ b/src/test/java/ch/hsr/geohash/util/BoundingBoxGeoHashIteratorTest.java
@@ -28,7 +28,7 @@ public class BoundingBoxGeoHashIteratorTest {
 			if (prev != null) {
 				Assert.assertTrue(prev.compareTo(gh) < 0);
 			}
-			Assert.assertTrue(newBox.contains(gh.getPoint()));
+			Assert.assertTrue(newBox.contains(gh.getOriginatingPoint()));
 			prev = gh;
 		}
 
@@ -49,7 +49,7 @@ public class BoundingBoxGeoHashIteratorTest {
 			if (prev != null) {
 				Assert.assertTrue(prev.compareTo(gh) < 0);
 			}
-			Assert.assertTrue(newBox.contains(gh.getPoint()));
+			Assert.assertTrue(newBox.contains(gh.getOriginatingPoint()));
 			prev = gh;
 		}
 

--- a/src/test/java/ch/hsr/geohash/util/BoundingBoxSamplerTest.java
+++ b/src/test/java/ch/hsr/geohash/util/BoundingBoxSamplerTest.java
@@ -28,7 +28,7 @@ public class BoundingBoxSamplerTest {
 
 		GeoHash prev = null;
 		while (gh != null) {
-			assertTrue(bbox.contains(gh.getPoint()));
+			assertTrue(bbox.contains(gh.getOriginatingPoint()));
 			assertFalse(hashes.contains(gh.toBase32()));
 			hashes.add(gh.toBase32());
 			if (prev != null) {

--- a/src/test/java/ch/hsr/geohash/util/GeoHashSizeTableTest.java
+++ b/src/test/java/ch/hsr/geohash/util/GeoHashSizeTableTest.java
@@ -63,7 +63,7 @@ public class GeoHashSizeTableTest {
 			// make the bounding box a little smaller than dLat/dLon
 			double dLat = GeoHashSizeTable.dLat(bits) - DELTA;
 			double dLon = GeoHashSizeTable.dLon(bits) - DELTA;
-			return new BoundingBox(45 - dLat, 45, 30, 30 - dLon);
+			return new BoundingBox(45 - dLat, 45, 30 - dLon, 30);
 		}
 
 		@Override


### PR DESCRIPTION
As dicussed in #38.

My changes could be considered "breaking" to some degree. The thing that's maybe breaking it is a "reordering" of the BoundingBox constructors arguments.
Before my changes the order of the latitude and longitude was of no importance and the min/max was used to assign the BoundingBox corners.
Since a (as called by @mauhiz) "modulo 360" adjustment needs fixed corner points in the constructor of the BoundingBox i changed the min/max handling to south/north/east/west handling.
With this change I also had to rearrange several test cases of yours to match the new specifiication and I suppose this will also happen to some users of this library.

```java
// New constructor with explicit definition of corner points
public BoundingBox(double southLatitude, double northLatitude, double westLongitude, double eastLongitude) {
        if (southLatitude > northLatitude)
            throw new IllegalArgumentException("The southLatitude must not be greater than the northLatitude");

        if (Math.abs(southLatitude) > 90 || Math.abs(northLatitude) > 90 || Math.abs(westLongitude) > 180 || Math.abs(eastLongitude) > 180) {
            throw new IllegalArgumentException("The supplied coordinates are out of range.");
        }

        this.northLatitude = northLatitude;
        this.westLongitude = westLongitude;

        this.southLatitude = southLatitude;
        this.eastLongitude = eastLongitude;

        intersects180Meridian = eastLongitude < westLongitude;
    }
```

I tried to be compliant to your `UpperLeft()` and `LowerRight()` - Methods but renamed them into `NorthWest()` and `SouthEast()` for clarity and consistence.
I also renamed some public methods to be consistent. You can rename them to the old names I would have no problem with that.

I got one thing I can't get right atm, or atleast I don't really understand what's happening there.
The `testStepsBetween()`-Test in GeoHashTest.java fails. If you could take this @kungfoo I'd greatly appreciate it.
Ofc you can delegate the issue to me if my changes are the cause but I don't fully understand what this function is doing atm.

There is a minor change regarding the `toString()`-Method in the GeoHash-class. The output is now padded to the left with zeros since the GeoHash can have leading zeros.