### PR TITLE
Shallow cloning on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,6 @@ jdk:
   - openjdk8
 
 install: mvn install -DskipTests -Dgpg.skip
+
+git:
+  depth: 1


### PR DESCRIPTION
Travis CI provide a way to shallow clone a repository. This has the obvious benefit of speed, since you only need to download a small number of commits.